### PR TITLE
adding new option.altDateField to specify a custom field to pull the date from using getdate.

### DIFF
--- a/lib/feedsub.js
+++ b/lib/feedsub.js
@@ -22,6 +22,7 @@ var FeedReader = module.exports = function(feed, options) {
     forceInterval: false,
     autoStart: false,
     emitOnStart: false,
+    altDateField: null,
     lastDate: null,
     history: [],
     maxHistory: 10,
@@ -176,6 +177,9 @@ FeedReader.prototype.read = function(callback) {
     parser.once('pubdate', getdate);
     parser.once('lastbuilddate', getdate);
     parser.once('updated', getdate);
+    if (self.options.altDateField) {
+      parser.once(self.options.altDateField, getdate)
+    }
 
 
     // change interval time if ttl available


### PR DESCRIPTION
When you need to pull the date from a field that is not pre-configure:
    // try to get date from one of the fields
    parser.once('pubdate', getdate);
    parser.once('lastbuilddate', getdate);
    parser.once('updated', getdate);

This option allows you to specify a custom field to get the date from:
    if (self.options.altDateField) {
      parser.once(self.options.altDateField, getdate)
    }
