### PR TITLE
Fixed validation of last date vs item date.

### DIFF
--- a/lib/feedsub.js
+++ b/lib/feedsub.js
@@ -223,7 +223,7 @@ FeedReader.prototype.read = function(callback) {
     var firstitem = function(item) {
 
       // if date is the same as last, abort
-      if (self.options.lastDate === date && (self.options.lastDate != undefined || date !== undefined)) {
+      if (date && self.options.lastDate === date) {
         return success([], true);
       }
 
@@ -240,7 +240,9 @@ FeedReader.prototype.read = function(callback) {
       }
 
       // continue if dates differ
-      self.options.lastDate = date;
+      if(date) {
+        self.options.lastDate = date;
+      }
       parser.on('item', getitems);
       getitems(item);
     };


### PR DESCRIPTION
Found a case for RSS compliant generated by Bamboo CI (example), where the last date was undefined.
Meaning at a moment  it was doing an undefined equals undefined validation, returning empty results.
Quick workaround for this issue.
