### PR TITLE
Correct typo'd "timeout" -> "interval"

### DIFF
--- a/lib/feedsub.js
+++ b/lib/feedsub.js
@@ -183,13 +183,13 @@ FeedReader.prototype.read = function(callback) {
 
 
     // change interval time if ttl available
-    if (!self.options.forceTimeout) {
+    if (!self.options.forceInterval) {
       parser.once('ttl', function(minutes) {
         minutes = parseInt(minutes, 10);
 
         // only update if ttl is longer than requested interval
-        if (minutes > self.options.timeout) {
-          self.options.timeout = minutes;
+        if (minutes > self.options.interval) {
+          self.options.interval = minutes;
           if (self.intervalid) {
             self.start(false);
           }


### PR DESCRIPTION
The option name is "forceInterval", but the code checked for "forceTimeout".
