### PR TITLE
Handling of gzipped and deflated content

### DIFF
--- a/lib/feedsub.js
+++ b/lib/feedsub.js
@@ -4,6 +4,7 @@ var _            = require('underscore');
 var FeedMe       = require('feedme');
 var NewsEmitter  = require('newsemitter');
 var request      = require('request');
+var zlib         = require('zlib');
 
 
 // These will be used for the skipdays tag.
@@ -267,12 +268,28 @@ FeedReader.prototype.read = function(callback) {
       }
     };
 
-    // Pipe data from response to parser.
-    res.on('data', function(chunk) {
+    var output;
+
+    // Pipe data from response to gunzipper/inflater.
+    switch(res.headers['content-encoding']){
+      case 'gzip':
+        output = zlib.createGunzip();
+        res.pipe(output);
+        break;
+      case 'deflate':
+        output = zlib.createInflate();
+        res.pipe(output);
+        break;
+      default:
+        output = res;
+    }
+
+    // Pipe data from gunzipper/inflater to parser.
+    output.on('data', function(chunk) {
       parser.write(chunk);
     });
 
-    res.on('end', function() {
+    output.on('end', function() {
       if (parser.close) { parser.close(); }
       if (!ended) { success(self.newitems); }
     });


### PR DESCRIPTION
I ran into issues when trying to subscribe to RSS feeds that were gzipped, so I added this small fix to unzip or inflate incoming content based on the response's content-encoding. I hope this helps others who ran into the same issue.